### PR TITLE
feat: 国际化 Resume 页面并接入配置文件数据

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -55,6 +55,41 @@
       "viewDetails": "View Details"
     }
   },
+  "resume": {
+    "subtitle": "Download my resume or view it online",
+    "previewOnline": "Preview Online",
+    "whatsIncluded": {
+      "title": "What's Included",
+      "items": {
+        "experience": "Professional Experience",
+        "skills": "Technical Skills",
+        "education": "Education & Certifications",
+        "projects": "Notable Projects",
+        "contact": "Contact Information"
+      }
+    },
+    "fileDetails": {
+      "title": "File Details",
+      "format": "Format",
+      "size": "Size",
+      "pages": "Pages",
+      "updated": "Updated"
+    },
+    "experienceHighlights": {
+      "title": "Experience Highlights"
+    },
+    "technicalSkills": {
+      "title": "Technical Skills",
+      "frontend": "Frontend",
+      "backend": "Backend"
+    },
+    "more": {
+      "title": "Want to Know More?",
+      "description": "Feel free to reach out if you have any questions about my experience or would like to discuss opportunities.",
+      "getInTouch": "Get In Touch",
+      "emailDirectly": "Email Directly"
+    }
+  },
   "contact": {
     "title": "Get In Touch",
     "subtitle": "I'd love to hear from you! Feel free to reach out for collaborations or just to say hi.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -55,6 +55,41 @@
       "viewDetails": "查看详情"
     }
   },
+  "resume": {
+    "subtitle": "下载我的简历或在线查看",
+    "previewOnline": "在线预览",
+    "whatsIncluded": {
+      "title": "包含内容",
+      "items": {
+        "experience": "工作经历",
+        "skills": "技术技能",
+        "education": "教育与证书",
+        "projects": "代表项目",
+        "contact": "联系信息"
+      }
+    },
+    "fileDetails": {
+      "title": "文件信息",
+      "format": "格式",
+      "size": "大小",
+      "pages": "页数",
+      "updated": "更新日期"
+    },
+    "experienceHighlights": {
+      "title": "经验亮点"
+    },
+    "technicalSkills": {
+      "title": "技术技能",
+      "frontend": "前端",
+      "backend": "后端"
+    },
+    "more": {
+      "title": "想了解更多？",
+      "description": "如对我的经历有疑问或希望交流合作，欢迎随时联系我。",
+      "getInTouch": "联系我",
+      "emailDirectly": "直接邮件"
+    }
+  },
   "contact": {
     "title": "联系我",
     "subtitle": "很高兴听到您的声音！欢迎联系我进行合作或者只是打个招呼。",

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -3,10 +3,16 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { usePersonalInfo } from '../hooks/usePersonalInfo';
 import { Download, Eye, FileText } from 'lucide-react';
+import { skillsData } from '../data/skills';
 
 const Resume = () => {
   const { t } = useTranslation();
   const { personalInfo } = usePersonalInfo();
+
+  // 仅取简短技能标签展示（各取前4项）
+  const frontendSkills = (skillsData?.[0]?.skills || []).slice(0, 4).map((s) => s.name);
+  const backendSkills = (skillsData?.[1]?.skills || []).slice(0, 4).map((s) => s.name);
+  const experiences = (personalInfo?.experience || []).slice(0, 2);
 
   const handleDownload = () => {
     // Create a dummy PDF download link
@@ -34,7 +40,7 @@ const Resume = () => {
               {t('nav.resume')}
             </h1>
             <p className="text-lg text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
-              Download my resume or view it online
+              {t('resume.subtitle')}
             </p>
           </motion.div>
         </div>
@@ -59,58 +65,58 @@ const Resume = () => {
                 {personalInfo.resume.filename}
               </h2>
               <p className="text-gray-600 dark:text-gray-400">
-                {personalInfo.title} Resume
+                {personalInfo.title} {t('nav.resume')}
               </p>
             </div>
 
             <div className="grid md:grid-cols-2 gap-6 mb-8">
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-                  What's Included
+                  {t('resume.whatsIncluded.title')}
                 </h3>
                 <ul className="space-y-2 text-gray-600 dark:text-gray-400">
                   <li className="flex items-center">
                     <div className="w-2 h-2 bg-blue-500 rounded-full mr-3"></div>
-                    Professional Experience
+                    {t('resume.whatsIncluded.items.experience')}
                   </li>
                   <li className="flex items-center">
                     <div className="w-2 h-2 bg-blue-500 rounded-full mr-3"></div>
-                    Technical Skills
+                    {t('resume.whatsIncluded.items.skills')}
                   </li>
                   <li className="flex items-center">
                     <div className="w-2 h-2 bg-blue-500 rounded-full mr-3"></div>
-                    Education & Certifications
+                    {t('resume.whatsIncluded.items.education')}
                   </li>
                   <li className="flex items-center">
                     <div className="w-2 h-2 bg-blue-500 rounded-full mr-3"></div>
-                    Notable Projects
+                    {t('resume.whatsIncluded.items.projects')}
                   </li>
                   <li className="flex items-center">
                     <div className="w-2 h-2 bg-blue-500 rounded-full mr-3"></div>
-                    Contact Information
+                    {t('resume.whatsIncluded.items.contact')}
                   </li>
                 </ul>
               </div>
 
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-                  File Details
+                  {t('resume.fileDetails.title')}
                 </h3>
                 <div className="space-y-3 text-gray-600 dark:text-gray-400">
                   <div className="flex justify-between">
-                    <span>Format:</span>
+                    <span>{t('resume.fileDetails.format')}:</span>
                     <span className="font-medium">PDF</span>
                   </div>
                   <div className="flex justify-between">
-                    <span>Size:</span>
+                    <span>{t('resume.fileDetails.size')}:</span>
                     <span className="font-medium">{personalInfo.resume.size}</span>
                   </div>
                   <div className="flex justify-between">
-                    <span>Pages:</span>
+                    <span>{t('resume.fileDetails.pages')}:</span>
                     <span className="font-medium">{personalInfo.resume.pages}</span>
                   </div>
                   <div className="flex justify-between">
-                    <span>Updated:</span>
+                    <span>{t('resume.fileDetails.updated')}:</span>
                     <span className="font-medium">{personalInfo.resume.lastUpdated}</span>
                   </div>
                 </div>
@@ -136,7 +142,7 @@ const Resume = () => {
                 className="flex items-center justify-center space-x-2 px-8 py-4 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors font-semibold"
               >
                 <Eye size={20} />
-                <span>Preview Online</span>
+                <span>{t('resume.previewOnline')}</span>
               </motion.button>
             </div>
           </div>
@@ -151,32 +157,20 @@ const Resume = () => {
             transition={{ duration: 0.8, delay: 0.4 }}
             className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg"
           >
-            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
-              Experience Highlights
-            </h3>
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('resume.experienceHighlights.title')}</h3>
             <div className="space-y-4">
-              <div className="border-l-4 border-blue-500 pl-4">
-                <h4 className="font-semibold text-gray-900 dark:text-white">
-                  Senior Frontend Developer
-                </h4>
-                <p className="text-blue-600 dark:text-blue-400 text-sm">
-                  Tech Company • 2022 - Present
-                </p>
-                <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
-                  Leading development of React applications and improving user experience
-                </p>
-              </div>
-              <div className="border-l-4 border-purple-500 pl-4">
-                <h4 className="font-semibold text-gray-900 dark:text-white">
-                  Full-Stack Developer
-                </h4>
-                <p className="text-purple-600 dark:text-purple-400 text-sm">
-                  Startup Inc. • 2020 - 2022
-                </p>
-                <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
-                  Developed full-stack applications using modern web technologies
-                </p>
-              </div>
+              {experiences.map((exp, idx) => {
+                const borderColors = ['border-blue-500', 'border-purple-500'];
+                const textColors = ['text-blue-600 dark:text-blue-400', 'text-purple-600 dark:text-purple-400'];
+                const colorIdx = idx % borderColors.length;
+                return (
+                  <div key={`${exp.title}-${idx}`} className={`border-l-4 ${borderColors[colorIdx]} pl-4`}>
+                    <h4 className="font-semibold text-gray-900 dark:text-white">{exp.title}</h4>
+                    <p className={`${textColors[colorIdx]} text-sm`}>{exp.company} • {exp.period}</p>
+                    <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">{exp.description}</p>
+                  </div>
+                );
+              })}
             </div>
           </motion.div>
 
@@ -187,16 +181,12 @@ const Resume = () => {
             transition={{ duration: 0.8, delay: 0.6 }}
             className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg"
           >
-            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
-              Technical Skills
-            </h3>
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('resume.technicalSkills.title')}</h3>
             <div className="space-y-3">
               <div>
-                <h4 className="font-semibold text-gray-900 dark:text-white mb-2">
-                  Frontend
-                </h4>
+                <h4 className="font-semibold text-gray-900 dark:text-white mb-2">{t('resume.technicalSkills.frontend')}</h4>
                 <div className="flex flex-wrap gap-2">
-                  {['React', 'TypeScript', 'Tailwind CSS', 'Next.js'].map((skill) => (
+                  {frontendSkills.map((skill) => (
                     <span
                       key={skill}
                       className="px-3 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded-full text-sm"
@@ -207,11 +197,9 @@ const Resume = () => {
                 </div>
               </div>
               <div>
-                <h4 className="font-semibold text-gray-900 dark:text-white mb-2">
-                  Backend
-                </h4>
+                <h4 className="font-semibold text-gray-900 dark:text-white mb-2">{t('resume.technicalSkills.backend')}</h4>
                 <div className="flex flex-wrap gap-2">
-                  {['Node.js', 'Python', 'PostgreSQL', 'MongoDB'].map((skill) => (
+                  {backendSkills.map((skill) => (
                     <span
                       key={skill}
                       className="px-3 py-1 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded-full text-sm"
@@ -232,24 +220,20 @@ const Resume = () => {
           transition={{ duration: 0.8, delay: 0.8 }}
           className="mt-16 text-center bg-blue-50 dark:bg-blue-900/20 rounded-lg p-8"
         >
-          <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-            Want to Know More?
-          </h3>
-          <p className="text-gray-600 dark:text-gray-400 mb-6">
-            Feel free to reach out if you have any questions about my experience or would like to discuss opportunities.
-          </p>
+          <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">{t('resume.more.title')}</h3>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">{t('resume.more.description')}</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
               href="/contact"
               className="inline-flex items-center justify-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold"
             >
-              Get In Touch
+              {t('resume.more.getInTouch')}
             </a>
             <a
               href="mailto:your.email@example.com"
               className="inline-flex items-center justify-center px-6 py-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors font-semibold"
             >
-              Email Directly
+              {t('resume.more.emailDirectly')}
             </a>
           </div>
         </motion.div>


### PR DESCRIPTION
- 新增 resume 命名空间到 i18n 配置 (en/zh)
- 替换 Resume.jsx 硬编码文案为 t() 函数调用
- 从 src/data/skills.js 读取技能数据渲染技术标签
- 从 src/config/personal-info.json 读取经验数据渲染工作经历
- 精简未使用的 i18n 键值，保持配置简洁

---

- Add resume namespace to i18n config (en/zh)
- Replace hardcoded text in Resume.jsx with t() function calls
- Read skill data from src/data/skills.js to render technical tags
- Read experience data from src/config/personal-info.json to render work history
- Clean up unused i18n keys to keep config concise"